### PR TITLE
Fixed bug that made follower cells red even when NOT in testing mode.…

### DIFF
--- a/config/PhysiCell_settings.xml
+++ b/config/PhysiCell_settings.xml
@@ -48,7 +48,7 @@
 
 		<Lesion_intialization description="Lesion_intialization" type="double" units="dimensionless">0</Lesion_intialization>
         <tumor_radius description="Initial cell mass radius" type="double" units="microns">175</tumor_radius>
-		<initial_leader_cell_fraction description="Average percentage of leaders initialized" type="double" units="dimensionless">0.0</initial_leader_cell_fraction>
+		<initial_leader_cell_fraction description="Average percentage of leaders initialized" type="double" units="dimensionless">0.2</initial_leader_cell_fraction>
 
 		<Cell_properties description="Cell_properties" type="double" units="dimensionless">0</Cell_properties>
 		<oxygen_uptake description="Default cell oxygen uptake rate" type="double" units="mmHg/min">0.0</oxygen_uptake>

--- a/custom_modules/AMIGOS-invasion.cpp
+++ b/custom_modules/AMIGOS-invasion.cpp
@@ -1128,9 +1128,20 @@ std::vector<std::string> AMIGOS_invasion_coloring_function( Cell* pCell )
 		return output; 
 	} 
 
-	// followers are yellow
-    if( pCell->type == 2 )
+	// followers are yellow except for the marker cells when running testing mode (then 20 % of cells are red)
+    
+	if( pCell->type == 2 )
     {
+		output[0] = "yellow";
+        output[2] = "yellow";	
+		
+		// Return yellow for followers and exit statement
+
+		if(parameters.ints("unit_test_setup")==0)
+		{return output;}
+
+		// Return red for 20% of followers if unit test is called for	
+
 		if( pCell->ID % 5 == 0)
 		{
 			output[0] = "red";
@@ -1138,8 +1149,8 @@ std::vector<std::string> AMIGOS_invasion_coloring_function( Cell* pCell )
         	return output;
 		}
 
-        output[0] = "yellow";
-        output[2] = "yellow";
+		// If doing unit testing AND cell not selected as marker cell, return yellow (assigned prior to first if statement)
+
         return output;
     }
 	


### PR DESCRIPTION
… altered XML to contain the default fraction leaders (0.2).

Necessary to keep convention of followers being yellow and leaders being blue, while still keeping red "tagged" marker cells for model unit tests.