### PR TITLE
Fixing typos in XML that messed up nanoHUB descriptions

### DIFF
--- a/config/PhysiCell_settings.xml
+++ b/config/PhysiCell_settings.xml
@@ -73,7 +73,7 @@
 		<chemotactic_substrate_decay_rate description="Chemotactic subsrate decay rate" type="double" units="1/minutes">0.1</chemotactic_substrate_decay_rate>
 
 		<Model_Selection_Parameters description="Allows selection of various cell motility-ECM models" type="double">0</Model_Selection_Parameters>
-		<cell_motility_ECM_interaction_model_selector description="Specifies the cell-ECM interaction model: follower chemotaxis/no follow hysteresis, follow hysteresis/no follower chemotaxis" type="string">follow hysteresis/no follower chemotaxis</cell_motility_ECM_interaction_model_selector>
+		<cell_motility_ECM_interaction_model_selector description="Specifies the cell-ECM interaction model: follower chemotaxis/no follower hysteresis, follower hysteresis/no follower chemotaxis" type="string">follower hysteresis/no follower chemotaxis</cell_motility_ECM_interaction_model_selector>
 
 		<Testing_and_setup_parameters description="Testing and setup parameters" type="double" units="dimensionlesss">0</Testing_and_setup_parameters>
 		<normalize_ECM_influenced_motility_vector hidden="false" type="bool">false</normalize_ECM_influenced_motility_vector>

--- a/config/PhysiCell_settings_default.xml
+++ b/config/PhysiCell_settings_default.xml
@@ -147,7 +147,7 @@
 		<chemotactic_substrate_decay_rate description="Chemotactic subsrate decay rate" type="double" units="1/minutes">0.1</chemotactic_substrate_decay_rate>
 
 		<Model_Selection_Parameters description="Allows selection of various cell motility-ECM models" type="double">0</Model_Selection_Parameters>
-		<cell_motility_ECM_interaction_model_selector description="Specifies the cell-ECM interaction model: follower chemotaxis/no follow hysteresis, follow hysteresis/no follower chemotaxis" type="string">follow hysteresis/no follower chemotaxis</cell_motility_ECM_interaction_model_selector>
+		<cell_motility_ECM_interaction_model_selector description="Specifies the cell-ECM interaction model: follower chemotaxis/no follower hysteresis, follower hysteresis/no follower chemotaxis" type="string">follower hysteresis/no follower chemotaxis</cell_motility_ECM_interaction_model_selector>
 
 		<Testing_and_setup_parameters description="Testing and setup parameters" type="double" units="dimensionlesss">0</Testing_and_setup_parameters>
 		<normalize_ECM_influenced_motility_vector hidden="false" type="bool">false</normalize_ECM_influenced_motility_vector>

--- a/custom_modules/AMIGOS-invasion.cpp
+++ b/custom_modules/AMIGOS-invasion.cpp
@@ -299,13 +299,13 @@ void create_cell_types( void )
 	
 	// Selecting cell-ECM interaction wrt to hyteriss
 	
-	if( parameters.strings("cell_motility_ECM_interaction_model_selector") == "follower chemotaxis/no follow hysteresis" || parameters.ints("unit_test_setup") == 1)
+	if( parameters.strings("cell_motility_ECM_interaction_model_selector") == "follower chemotaxis/no follower hysteresis" || parameters.ints("unit_test_setup") == 1)
 	{
 		follower_cell.functions.update_migration_bias = ECM_informed_motility_update_w_chemotaxis;
 		std::cout<<"I selected follower chemotaxsis" << std::endl;
 	}
 
-	else if( parameters.strings("cell_motility_ECM_interaction_model_selector") == "follow hysteresis/no follower chemotaxis")
+	else if( parameters.strings("cell_motility_ECM_interaction_model_selector") == "follower hysteresis/no follower chemotaxis")
 	{
 		follower_cell.functions.update_migration_bias = ECM_informed_motility_update_model_w_memory;
 		std::cout<<"I selected follower hysteresis" << std::endl;


### PR DESCRIPTION
Fixing typos in XML that messed up nanoHUB descriptions