### PR TITLE
Minor bug fixes (ECM element reorientation and compiling on windows) and added CI

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -16,7 +16,7 @@ jobs:
     
     - name: Build model
       run: |
-        make
+        make PHYSICELL_CPP=g++-11
         
     - name: Run model
       run: |

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -2,6 +2,7 @@ name: Test MacOSX
 run-name: ${{ github.actor }} 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install dependencies
-    run : brew install gcc@11
+      run : brew install gcc@11
     
     - name: Build model
       run: |

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,7 +1,6 @@
 name: Test MacOSX
 run-name: ${{ github.actor }} 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,6 +1,7 @@
 name: Test MacOSX
 run-name: ${{ github.actor }} 
 on:
+  push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,4 +1,4 @@
-name: Test Ubuntu
+name: Test MacOSX
 run-name: ${{ github.actor }} 
 on:
   push:
@@ -6,10 +6,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Install dependencies
+    run : brew install gcc@11
     
     - name: Build model
       run: |

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -1,7 +1,6 @@
 name: Test Ubuntu
 run-name: ${{ github.actor }} 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -2,6 +2,7 @@ name: Test Ubuntu
 run-name: ${{ github.actor }} 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -1,0 +1,20 @@
+name: Test Ubuntu
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Build model
+      run: |
+        make
+        
+    - name: Run model
+      run: |
+        ./AMIGOS-invasion

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -1,6 +1,7 @@
 name: Test Ubuntu
 run-name: ${{ github.actor }} 
 on:
+  push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,16 +1,19 @@
 name: Test Windows
 run-name: ${{ github.actor }} 
 on:
-  push:
   pull_request:
 
 jobs:
   build:
     runs-on: windows-latest
 
+    defaults:
+      run:
+        shell: msys2 {0}
+
     steps:
     - uses: actions/checkout@v3
-    
+
     - uses: msys2/setup-msys2@v2
       with:
         update: true

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,6 +1,7 @@
 name: Test Windows
 run-name: ${{ github.actor }} 
 on:
+  push:
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
+    - uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: base-devel flex bison gcc make diffutils mingw-w64-x86_64-toolchain mingw-w64-x86_64-ca-certificates
+    
     - name: Build model
       run: |
         make

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,4 +1,4 @@
-name: Test Ubuntu
+name: Test Windows
 run-name: ${{ github.actor }} 
 on:
   push:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -2,6 +2,7 @@ name: Test Windows
 run-name: ${{ github.actor }} 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -17,4 +17,4 @@ jobs:
         
     - name: Run model
       run: |
-        ./AMIGOS-invasion
+        .\\AMIGOS-invasion

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -211,8 +211,7 @@ void Cell::update_motility_vector( double dt_ )
 			cos_phi = 0.0;
 		}
 		
-		std::vector<double> randvec; 
-		randvec.resize(3,sin_phi); 
+		std::vector<double> randvec(3,sin_phi); 
 		
 		randvec[0] *= cos( temp_angle ); // cos(theta)*sin(phi)
 		randvec[1] *= sin( temp_angle ); // sin(theta)*sin(phi)

--- a/custom_modules/AMIGOS-invasion_uncoupled.cpp
+++ b/custom_modules/AMIGOS-invasion_uncoupled.cpp
@@ -999,7 +999,7 @@ void setup_tissue( void )
 		{
 			Cell* pC;
 			pC = create_cell(leader_cell);
-			pC->assign_position(0.0, 0.0, 0.0)
+			pC->assign_position(0.0, 0.0, 0.0);
 		}
 
 		else if(parameters.strings("cell_setup") == "random")

--- a/custom_modules/AMIGOS-invasion_uncoupled.cpp
+++ b/custom_modules/AMIGOS-invasion_uncoupled.cpp
@@ -2240,9 +2240,9 @@ void ecm_update_from_cell_motility_vector(Cell* pCell , Phenotype& phenotype , d
 		double r_realignment = r_0 * (1-anisotropy);
 
 		double ddotf;
-		std::vector<double> norm_cell_motility;
-		norm_cell_motility.resize(3,0.0);
-		norm_cell_motility = phenotype.motility.motility_vector;
+		std::vector<double> norm_cell_motility = phenotype.motility.motility_vector;
+		// norm_cell_motility.resize(3,0.0);
+		// norm_cell_motility = phenotype.motility.motility_vector;
 		normalize(&norm_cell_motility);
 
 		ddotf = dot_product(ECM_orientation, norm_cell_motility);
@@ -2351,9 +2351,9 @@ void ecm_update_from_cell_velocity_vector(Cell* pCell , Phenotype& phenotype , d
     double r_realignment = r_0 * (1-anisotropy);
 
 	double ddotf;
-	std::vector<double> norm_cell_velocity;
-	norm_cell_velocity.resize(3,0.0);
-	norm_cell_velocity = pCell->velocity;
+	std::vector<double> norm_cell_velocity = pCell->velocity;
+	// norm_cell_velocity.resize(3,0.0);
+	// norm_cell_velocity = pCell->velocity;
 	normalize(&norm_cell_velocity);
 
 	ddotf = dot_product(ECM_orientation, norm_cell_velocity);

--- a/custom_modules/AMIGOS-invasion_uncoupled.cpp
+++ b/custom_modules/AMIGOS-invasion_uncoupled.cpp
@@ -998,10 +998,8 @@ void setup_tissue( void )
 		if(parameters.strings("cell_setup") == "single")
 		{
 			Cell* pC;
-			pC = create_cell();
-			pC->assign_position(0.0, 0.0, 0.0);
-			// std::cin.get();
-
+			pC = create_cell(leader_cell);
+			pC->assign_position(0.0, 0.0, 0.0)
 		}
 
 		else if(parameters.strings("cell_setup") == "random")
@@ -2248,7 +2246,7 @@ void ecm_update_from_cell_motility_vector(Cell* pCell , Phenotype& phenotype , d
 		normalize(&norm_cell_motility);
 
 		ddotf = dot_product(ECM_orientation, norm_cell_motility);
-		
+
 		ECM_orientation = sign_function(ddotf) * ECM_orientation; // flips the orientation vector so that it is aligned correctly with the moving cell for proper reoirentation later.
 		
 		std::vector<double> f_minus_d;
@@ -2258,6 +2256,10 @@ void ecm_update_from_cell_motility_vector(Cell* pCell , Phenotype& phenotype , d
 
 		for(int i = 0; i < 3; i++)
 		{
+			if (ddotf<0.0)
+			{
+				ECM_orientation = -1.0 * ECM_orientation;
+			}
 			f_minus_d[i] = ECM_orientation[i] - norm_cell_motility[i]; // 06.05.19 - fixed 
 			ecm.ecm_voxels[nearest_ecm_voxel_index].ecm_fiber_alignment[i] -= dt * r_realignment * f_minus_d[i]; 
 		}

--- a/custom_modules/AMIGOS-invasion_uncoupled.cpp
+++ b/custom_modules/AMIGOS-invasion_uncoupled.cpp
@@ -675,8 +675,7 @@ void setup_microenvironment( void )
 	default_microenvironment_options.Dirichlet_condition_vector = bc_vector;
     
 	// Temperarily eliminating leader/follower signal	
-    
-	default_microenvironment_options.Dirichlet_condition_vector[1] = 0; // normoxic conditions
+	// default_microenvironment_options.Dirichlet_condition_vector[1] = 0; // normoxic conditions
 	// default_microenvironment_options.Dirichlet_condition_vector[2] = 0; // normoxic conditions
     
 	initialize_microenvironment(); 


### PR DESCRIPTION
This merge addressed a bug report regarding reorientation of ECM element orientations
[Bug fix for ECM element reorientation.](https://github.com/PhysiCell-Models/collective-invasion/commit/904c901d04e5bd808994d6ae041ad4c93e184ba5), adds three GitHub action workflows (over several commits), and finally fixes a compile warning and subsequent execution error on Windows [Changed syntax around lines 2244 and 2355 - hoping that the change wi…](https://github.com/PhysiCell-Models/collective-invasion/commit/5afd7119876b727673ef51ecdb5baa004723f913).

Thank you @drbergman for the bug report and @heberlr for testing on Windows. 